### PR TITLE
[squid:S2864] "entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/src/main/java/focusedCrawler/link/classifier/LinkClassifierAuthority.java
+++ b/src/main/java/focusedCrawler/link/classifier/LinkClassifierAuthority.java
@@ -3,6 +3,7 @@ package focusedCrawler.link.classifier;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.Map;
 
 import weka.classifiers.Classifier;
 import weka.core.Instances;
@@ -45,12 +46,12 @@ public class LinkClassifierAuthority implements LinkClassifier{
 		          
 		          int count = 0;
 		          
-		          for (String urlStr : urlWords.keySet()) {
+		          for (Map.Entry<String, Instance> entry : urlWords.entrySet()) {
 		              
-		        	  URL url = new URL(urlStr);
+		        	  URL url = new URL(entry.getKey());
 		        	  double relevance = -1;
 		        	  if(!page.getURL().getHost().equals(url.getHost())){
-		        		  Instance instance = urlWords.get(urlStr);
+		        		  Instance instance = entry.getValue();
 		        		  double[] values = instance.getValues();
 		        		  weka.core.Instance instanceWeka = new weka.core.Instance(1, values);
 		        		  instanceWeka.setDataset(instances);
@@ -87,11 +88,11 @@ public class LinkClassifierAuthority implements LinkClassifier{
 		  try{
 		      HashMap<String, Instance> urlWords = wrapper.extractLinks(ln, attributes);
 		      
-	    	  for (String url : urlWords.keySet()) {
+	    	  for (Map.Entry<String, Instance> entry : urlWords.entrySet()) {
 		    	  double relevance = -1;
-		    	  if(isRootPage(url)){
+		    	  if(isRootPage(entry.getKey())){
 		    		  if(classifier != null){
-		    			  Instance instance = (Instance)urlWords.get(url);
+		    			  Instance instance = (Instance) entry.getValue();
 		    			  double[] values = instance.getValues();
 		    			  weka.core.Instance instanceWeka = new weka.core.Instance(1, values);
 		    			  instanceWeka.setDataset(instances);
@@ -104,7 +105,7 @@ public class LinkClassifierAuthority implements LinkClassifier{
 		    			  relevance = LinkRelevance.DEFAULT_AUTH_RELEVANCE+1;		            	
 		    		  }
 		    	  }
-	    		  linkRel = new LinkRelevance(new URL(url),relevance);
+	    		  linkRel = new LinkRelevance(new URL(entry.getKey()),relevance);
 		      }
 		  } catch (MalformedURLException ex) {
 			  ex.printStackTrace();

--- a/src/main/java/focusedCrawler/util/vsm/VSMVector.java
+++ b/src/main/java/focusedCrawler/util/vsm/VSMVector.java
@@ -33,6 +33,7 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Vector;
 
 import org.cyberneko.html.parsers.DOMParser;
@@ -587,9 +588,9 @@ public class VSMVector {
     		total = total + elem.getWeight();
     	}
     	if(total != 0){
-    	    for(String word : elems.keySet()) {
-    	        VSMElement elem = elems.get(word);
-    	        elems.put(word,new VSMElement(word,elem.getWeight()/max));
+    	    for(Map.Entry<String, VSMElement> entry : elems.entrySet()) {
+    	        VSMElement elem = entry.getValue();
+    	        elems.put(entry.getKey(),new VSMElement(entry.getKey(),elem.getWeight()/max));
     	    }
     	}
     }
@@ -600,9 +601,9 @@ public class VSMVector {
     		total = total + elem.getWeight();
     	}
     	if(total != 0){
-    	    for(String word : elems.keySet()) {
-    			VSMElement elem = elems.get(word);
-    			elems.put(word,new VSMElement(word,elem.getWeight()/total));
+    	    for(Map.Entry<String, VSMElement> entry : elems.entrySet()) {
+    			VSMElement elem = entry.getValue();
+    			elems.put(entry.getKey(),new VSMElement(entry.getKey(),elem.getWeight()/total));
     		}
     	}
     }
@@ -614,18 +615,18 @@ public class VSMVector {
 		  total = total +  Math.sqrt(elem.getWeight());
 	  }
 	  if(total != 0){
-	      for(String word : elems.keySet()) {
-			  VSMElement elem = elems.get(word);
-			  elems.put(word,new VSMElement(word,Math.sqrt(elem.getWeight())/total));
+	      for(Map.Entry<String, VSMElement> entry : elems.entrySet()) {
+			  VSMElement elem = entry.getValue();
+			  elems.put(entry.getKey(),new VSMElement(entry.getKey(),Math.sqrt(elem.getWeight())/total));
 		  }
 	  }
   }
 
   public void normalizeOverElements() {
       double total = elems.size();
-      for(String word : elems.keySet()) {
-          VSMElement elem = elems.get(word);
-          elems.put(word, new VSMElement(word, elem.getWeight() / total));
+      for(Map.Entry<String, VSMElement> entry : elems.entrySet()) {
+          VSMElement elem = entry.getValue();
+          elems.put(entry.getKey(), new VSMElement(entry.getKey(), elem.getWeight() / total));
       }
   }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864

Please let me know if you have any questions.
Ayman Abdelghany.