### PR TITLE
[squid:S2259] Null pointers should not be dereferenced

### DIFF
--- a/src/main/java/focusedCrawler/link/classifier/builder/WordField.java
+++ b/src/main/java/focusedCrawler/link/classifier/builder/WordField.java
@@ -80,6 +80,8 @@ public class WordField implements Serializable {
   }
 
   public boolean equals(WordField wordField){
+    if (wordField == null)
+      return false;
     boolean ret = false;
     if(wordField.getWord().equals(word)){
       ret = true;

--- a/src/main/java/focusedCrawler/link/classifier/builder/WordField.java
+++ b/src/main/java/focusedCrawler/link/classifier/builder/WordField.java
@@ -81,8 +81,8 @@ public class WordField implements Serializable {
 
   public boolean equals(WordField wordField){
     if (wordField == null)
-      return false;
-    boolean ret = false;
+		return false;
+	boolean ret = false;
     if(wordField.getWord().equals(word)){
       ret = true;
     }

--- a/src/main/java/focusedCrawler/link/classifier/builder/WordFrequency.java
+++ b/src/main/java/focusedCrawler/link/classifier/builder/WordFrequency.java
@@ -55,6 +55,8 @@ public class WordFrequency {
     }
 
     public boolean equals(WordFrequency wordFrequency) {
+        if (wordFrequency == null)
+            return false;
         return this.getWord().equals(wordFrequency.getWord());
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2259 - “Null pointers should not be dereferenced”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2259

Please let me know if you have any questions.
Ayman Abdelghany.
