### PR TITLE
[squid:S2131] Primitives should not be boxed just for "String" conversion

### DIFF
--- a/src/main/java/focusedCrawler/link/BipartiteGraphRepository.java
+++ b/src/main/java/focusedCrawler/link/BipartiteGraphRepository.java
@@ -367,7 +367,7 @@ public class BipartiteGraphRepository {
 				maxId = "0";
 			}
 			int newId = Integer.parseInt(maxId) + 1;
-			id = newId+"";
+			id = Integer.toString(newId);
 			url2id.put(url, id);
 			url2id.put("MAX", id);
 		}

--- a/src/main/java/focusedCrawler/util/ParameterFile.java
+++ b/src/main/java/focusedCrawler/util/ParameterFile.java
@@ -83,7 +83,7 @@ public class ParameterFile {
         for (int i = 0; i < args.length; i++) {
             Vector v = new Vector();
             v.addElement(args[i].trim());
-            hash.put("" + i, v);
+            hash.put(Integer.toString(i), v);
         }
     }
 

--- a/src/main/java/focusedCrawler/util/parser/PaginaURL.java
+++ b/src/main/java/focusedCrawler/util/parser/PaginaURL.java
@@ -983,7 +983,7 @@ public class PaginaURL {
                         /* faz o token da string */
                         if ((caracterFazParteDePalavra(c)) || (c == ';')
                                 || (c == '&')) {
-                            str += converteChar(c);
+                            str += Character.toString(converteChar(c));
                             n++;
                             int begin = str.indexOf("&#");
                             int end = str.indexOf(";");
@@ -992,7 +992,7 @@ public class PaginaURL {
     							try {
                                 	int hex = Integer.parseInt(specialchar);
         							char uni = (char)hex;
-        							String unicode =  uni + "";
+        							String unicode =  Character.toString(uni);
         							str = str.substring(0,begin) + unicode;
 //        							System.out.println(unicode);
                                 	pos_caracter_especial = -1;
@@ -1050,7 +1050,7 @@ public class PaginaURL {
 //                                	if(!Character.isLetterOrDigit(c)){
 //                                		c = ' ';
 //                                	}
-                                    titulo += c;
+                                    titulo += Character.toString(c);
                                 }
 
                                 n++;
@@ -1138,7 +1138,7 @@ public class PaginaURL {
                         if (em_script) {
                             if ( c != '>'){
                                 if ( "/script".startsWith(str + c) || "/SCRIPT".startsWith(str + c) || "/style".startsWith(str + c) || "/STYLE".startsWith(str + c)) {
-                                    str +=c;
+                                    str +=Character.toString(c);
                                 }
                                 else {
                                     str = "";
@@ -1207,7 +1207,7 @@ public class PaginaURL {
                                 } else if ((c != '\r') && (c != '\n')) {
 
                                     // System.out.println("Estou NO CAMINHO CERTO!!!!");
-                                    str += c;
+                                    str += Character.toString(c);
                                     n++;
                                 } else {
                                     fimDeString = true;
@@ -1369,11 +1369,11 @@ public class PaginaURL {
 //System.out.println("[ATRIBUTO c='"+c+"', estado=IGUAL], atributo="+atributo);
                                 /* if non-null attribute name */
                             } else {
-                                str += c;
+                                str += Character.toString(c);
                                 n++;
                             }
                         } else {
-                            str += c;
+                            str += Character.toString(c);
                             n++;
                         }
 
@@ -1468,7 +1468,7 @@ public class PaginaURL {
                                 } else {
                                     if ((c != '\0') && (c != '\r')
                                             && (c != '\n') && (c != '"')) {
-                                        str += c;
+                                        str += Character.toString(c);
                                     } else {
                                         if (c == '"') {
                                             estado = ATRIBUTO;
@@ -1505,7 +1505,7 @@ public class PaginaURL {
                                 } else {
                                     if ((c != '\0') && (c != '\r')
                                             && (c != '\n') && (c != '"')) {
-                                        str += c;
+                                        str += Character.toString(c);
                                     }
                                 }
                             }
@@ -1552,13 +1552,13 @@ public class PaginaURL {
                                 estado = ATRIBUTO;    /* if non-null value name */
                                 n++;
                             } else if (include) {
-                                str += c;
+                                str += Character.toString(c);
                                 n++;
                             } else {
                                 n++;
                             }
                         } else if (include) {
-                            str += c;
+                            str += Character.toString(c);
                             n++;
                         } else {
                             n++;
@@ -2468,7 +2468,7 @@ public class PaginaURL {
             int index_ponto = file.lastIndexOf('.');
 
             if (index_barra > index_ponto &&!file.endsWith("/")) {
-                file += '/';
+                file += Character.toString('/');
 
                 // System.out.println("pu file2='"+file+"'");
                 // System.out.println("--------------------------");

--- a/src/main/java/focusedCrawler/util/string/AbstractStopList.java
+++ b/src/main/java/focusedCrawler/util/string/AbstractStopList.java
@@ -484,7 +484,7 @@ public abstract class AbstractStopList implements StopList {
 
     public synchronized boolean eLetra( char c ) {
 
-        int value = (int)(Acentos.retirarAcentosANSI(""+c).charAt(0));
+        int value = (int)(Acentos.retirarAcentosANSI(Character.toString(c)).charAt(0));
 
         return ( 65 <= value && value <= 90 ) || ( 97 <= value && value <= 122 );
 

--- a/src/main/java/focusedCrawler/util/string/Acentos.java
+++ b/src/main/java/focusedCrawler/util/string/Acentos.java
@@ -311,15 +311,15 @@ public class Acentos {
 
             return substituirCorretamente( pedaco,caracter,escollhaLetraRing(caracter) );
 
-        if( pedaco.endsWith("AElig;") ) return ""+'Æ';
+        if( pedaco.endsWith("AElig;") ) return Character.toString('Æ');
 
-        if( pedaco.endsWith("aelig;") ) return ""+'æ';
+        if( pedaco.endsWith("aelig;") ) return Character.toString('æ');
 
-        if( pedaco.endsWith("THORN;") ) return ""+'Þ';
+        if( pedaco.endsWith("THORN;") ) return Character.toString('Þ');
 
-        if( pedaco.endsWith("thorn;") ) return ""+'þ';
+        if( pedaco.endsWith("thorn;") ) return Character.toString('þ');
 
-        if( pedaco.endsWith("szlig;") ) return ""+'ß';
+        if( pedaco.endsWith("szlig;") ) return Character.toString('ß');
 
         return pedaco;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2131 - “Primitives should not be boxed just for "String" conversion”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131

Please let me know if you have any questions.
Ayman Abdelghany.
