### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/src/main/java/focusedCrawler/crawler/crawlercommons/CrawlerCommons.java
+++ b/src/main/java/focusedCrawler/crawler/crawlercommons/CrawlerCommons.java
@@ -6,6 +6,9 @@ import java.util.Properties;
 
 public class CrawlerCommons {
 
+    private CrawlerCommons() {
+    }
+
     public static String getVersion() {
         String path = "/version.prop";
         InputStream stream = CrawlerCommons.class.getResourceAsStream(path);

--- a/src/main/java/focusedCrawler/crawler/crawlercommons/fetcher/EncodingUtils.java
+++ b/src/main/java/focusedCrawler/crawler/crawlercommons/fetcher/EncodingUtils.java
@@ -35,6 +35,9 @@ public class EncodingUtils {
     private static final int EXPECTED_DEFLATE_COMPRESSION_RATIO = 5;
     private static final int BUF_SIZE = 4096;
 
+    private EncodingUtils() {
+    }
+
     public static class ExpandedResult {
         private byte[] _expanded;
         private boolean _isTruncated;

--- a/src/main/java/focusedCrawler/tools/CborDataReclassifier.java
+++ b/src/main/java/focusedCrawler/tools/CborDataReclassifier.java
@@ -18,6 +18,9 @@ public class CborDataReclassifier {
     static final ObjectMapper cborMapper = new ObjectMapper(new CBORFactory());
     static final ObjectMapper jsonMapper = new ObjectMapper();
 
+    private CborDataReclassifier() {
+    }
+
     public static void main(String[] args) throws IOException {
 
         Path inputLocation = Paths.get(args[0]);

--- a/src/main/java/focusedCrawler/tools/CborToGzipCompressor.java
+++ b/src/main/java/focusedCrawler/tools/CborToGzipCompressor.java
@@ -14,7 +14,10 @@ public class CborToGzipCompressor {
     
     static final ObjectMapper cborMapper = new ObjectMapper(new CBORFactory());
     static final ObjectMapper jsonMapper = new ObjectMapper();
-    
+
+    private CborToGzipCompressor() {
+    }
+
     public static void main(String[] args) throws IOException {
         
         String inputLocation = args[0];

--- a/src/main/java/focusedCrawler/tools/CrawlerEvalFile.java
+++ b/src/main/java/focusedCrawler/tools/CrawlerEvalFile.java
@@ -17,7 +17,10 @@ import focusedCrawler.target.model.TargetModelJson;
 public class CrawlerEvalFile {
     
     static final ObjectMapper jsonMapper = new ObjectMapper();
-    
+
+    private CrawlerEvalFile() {
+    }
+
     public static void main(String[] args) throws IOException {
         
         Path path = Paths.get("/data/memex/crawleval/onion");

--- a/src/main/java/focusedCrawler/tools/DumpDataFromElasticSearch.java
+++ b/src/main/java/focusedCrawler/tools/DumpDataFromElasticSearch.java
@@ -25,7 +25,10 @@ public class DumpDataFromElasticSearch {
     
     static final ObjectMapper cborMapper = new ObjectMapper(new CBORFactory());
     static final ObjectMapper jsonMapper = new ObjectMapper();
-    
+
+    private DumpDataFromElasticSearch() {
+    }
+
     static class DDTDocument {
         public String url;
         public String html;

--- a/src/main/java/focusedCrawler/tools/ElasticSearchIndexer.java
+++ b/src/main/java/focusedCrawler/tools/ElasticSearchIndexer.java
@@ -51,7 +51,10 @@ public class ElasticSearchIndexer {
     static final ObjectMapper jsonMapper = new ObjectMapper();
     
     static final String format = "yyyy-MM-dd'T'HH:mm:ss";
-    
+
+    private ElasticSearchIndexer() {
+    }
+
     public static void main(String[] args) throws Exception {
         
         CommandLineParser parser = new DefaultParser();

--- a/src/main/java/focusedCrawler/util/string/StringHashFunctions.java
+++ b/src/main/java/focusedCrawler/util/string/StringHashFunctions.java
@@ -26,6 +26,9 @@ package focusedCrawler.util.string;
 
 public class StringHashFunctions {
 
+    private StringHashFunctions() {
+    }
+
     /**
 
      * usa a funcao lookup para o hashcode

--- a/src/test/java/focusedCrawler/crawler/crawlercommons/test/TestUtils.java
+++ b/src/test/java/focusedCrawler/crawler/crawlercommons/test/TestUtils.java
@@ -25,4 +25,6 @@ public class TestUtils {
     // fake name.
     public static final UserAgent CC_TEST_AGENT = new UserAgent("test", "test@domain.com", "http://test.domain.com");
 
+    private TestUtils() {
+    }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.
