### PR TITLE
[squid:S1149] Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/src/main/java/focusedCrawler/link/BipartiteGraphRepository.java
+++ b/src/main/java/focusedCrawler/link/BipartiteGraphRepository.java
@@ -3,9 +3,10 @@ package focusedCrawler.link;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.StringTokenizer;
-import java.util.Vector;
 
 import focusedCrawler.util.parser.BackLinkNeighborhood;
 import focusedCrawler.util.parser.LinkNeighborhood;
@@ -126,7 +127,7 @@ public class BipartiteGraphRepository {
 					String title = fields[1];
 					if(title != null){
 						StringTokenizer tokenizer = new StringTokenizer(title," ");
-						Vector<String> anchorTemp = new Vector<String>();
+						List<String> anchorTemp = new ArrayList<String>();
 						while(tokenizer.hasMoreTokens()){
 							 anchorTemp.add(tokenizer.nextToken());
 			   		  	}
@@ -153,7 +154,7 @@ public class BipartiteGraphRepository {
 					String title = fields[1];
 					if(title != null){
 						StringTokenizer tokenizer = new StringTokenizer(title," ");
-						Vector<String> anchorTemp = new Vector<String>();
+						List<String> anchorTemp = new ArrayList<String>();
 						while(tokenizer.hasMoreTokens()){
 							 anchorTemp.add(tokenizer.nextToken());
 			   		  	}
@@ -223,7 +224,7 @@ public class BipartiteGraphRepository {
 		if(strLinks == null){
 			return null;
 		} else {
-			Vector<BackLinkNeighborhood> tempBacklinks = new Vector<BackLinkNeighborhood> (); 
+			List<BackLinkNeighborhood> tempBacklinks = new ArrayList<BackLinkNeighborhood> ();
 			String[] backlinkIds = strLinks.split("###");
 			for (int i = 0; i < backlinkIds.length; i++) {
 				String url_title = hubID.get(backlinkIds[i]);
@@ -253,7 +254,7 @@ public class BipartiteGraphRepository {
 		if(strLinks == null){
 			return null;
 		} else {
-			Vector<LinkNeighborhood> tempLNs = new Vector<LinkNeighborhood> (); 
+			List<LinkNeighborhood> tempLNs = new ArrayList<LinkNeighborhood> ();
 			String[] linkIds = strLinks.split("###");
 			for (int i = 0; i < linkIds.length; i++) {
 				String lnStr = authID.get(linkIds[i]);

--- a/src/main/java/focusedCrawler/link/backlink/MozBacklinkApi.java
+++ b/src/main/java/focusedCrawler/link/backlink/MozBacklinkApi.java
@@ -82,7 +82,7 @@ public class MozBacklinkApi implements BacklinkApi {
         conn.setReadTimeout(readTimeout);
 
         BufferedReader inCon = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         String inputLine;
         while ((inputLine = inCon.readLine()) != null) {
             buffer.append(inputLine + " ");

--- a/src/main/java/focusedCrawler/link/classifier/LinkClassifierRegression.java
+++ b/src/main/java/focusedCrawler/link/classifier/LinkClassifierRegression.java
@@ -5,9 +5,10 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 
 import focusedCrawler.link.classifier.builder.Instance;
 import focusedCrawler.link.classifier.builder.WordField;
@@ -121,9 +122,9 @@ public class LinkClassifierRegression implements LinkClassifier{
 	      String[] attributes = config.getParam("ATTRIBUTES", " ");
 	      
 	      String[][] fieldWords = new String[WordField.FIELD_NAMES.length][];
-	      Vector<String> tempURL = new Vector<String>();
-	      Vector<String> tempAnchor = new Vector<String>();
-	      Vector<String> tempAround = new Vector<String>();
+	      List<String> tempURL = new ArrayList<String>();
+	      List<String> tempAnchor = new ArrayList<String>();
+	      List<String> tempAround = new ArrayList<String>();
 	      
 	      for (int i = 0; i < attributes.length; i++) {
 	    	  if(attributes[i].contains("url_")){
@@ -140,9 +141,9 @@ public class LinkClassifierRegression implements LinkClassifier{
 	      fieldWords[WordField.URLFIELD] = new String[tempURL.size()];
 	      fieldWords[WordField.ANCHOR] = new String[tempAnchor.size()];
 	      fieldWords[WordField.AROUND] = new String[tempAround.size()];
-	      tempURL.copyInto(fieldWords[WordField.URLFIELD]);
-	      tempAnchor.copyInto(fieldWords[WordField.ANCHOR]);
-	      tempAround.copyInto(fieldWords[WordField.AROUND]);
+	      tempURL.toArray(fieldWords[WordField.URLFIELD]);
+	      tempAnchor.toArray(fieldWords[WordField.ANCHOR]);
+	      tempAround.toArray(fieldWords[WordField.AROUND]);
 	      wrapper.setFeatures(fieldWords);
 	      
 	      InputStream is =  new FileInputStream(config.getParam("FILE_CLASSIFIER"));

--- a/src/main/java/focusedCrawler/link/classifier/builder/Instance.java
+++ b/src/main/java/focusedCrawler/link/classifier/builder/Instance.java
@@ -87,7 +87,7 @@ public class Instance {
 
     public String toString() {
 
-        StringBuffer temp = new StringBuffer();
+        StringBuilder temp = new StringBuilder();
         for (int i = 0; i < features.length; i++) {
             // if(values[i] > 0 && features[i].indexOf("text") == -1 &&
             // features[i].indexOf("title") == -1){

--- a/src/main/java/focusedCrawler/query/RelevanceFeedback.java
+++ b/src/main/java/focusedCrawler/query/RelevanceFeedback.java
@@ -321,7 +321,7 @@ public class RelevanceFeedback {
 		byte[] accountKeyBytes = Base64.encodeBase64((accountKey + ":" + accountKey).getBytes());
 		String accountKeyEnc = new String(accountKeyBytes);
 		URL url = null;
-		StringBuffer output = new StringBuffer();
+		StringBuilder output = new StringBuilder();
 		try {
 			url = new URL("https://api.datamarket.azure.com/Data.ashx/Bing/SearchWeb/v1/Web?Query=%27" + keyword + "%27&$top="+ top);
 			System.out.println(url);
@@ -363,7 +363,7 @@ public class RelevanceFeedback {
 	    	return null;
 	    }
 	    
-	    StringBuffer buffer = new StringBuffer();
+	    StringBuilder buffer = new StringBuilder();
 	    try{
 	      BufferedReader inCon = new BufferedReader(new InputStreamReader(yc.
 	          getInputStream()));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.
Ayman Abdelghany.
