### PR TITLE
Ignoring links in link tag ending with .css or .js

### DIFF
--- a/src/main/java/focusedCrawler/util/parser/PaginaURL.java
+++ b/src/main/java/focusedCrawler/util/parser/PaginaURL.java
@@ -946,8 +946,11 @@ public class PaginaURL {
 //                                System.out.println("CREATE LINK:"  + urlTemp);
                             } else if (tagName.equals("link")
                                        && atributo.equals("href")) {
-                                String urlTemp = adicionaLink(str, base);
-                                if(urlTemp!= null && urlTemp.startsWith("http")){
+                            	String urlTemp = null;
+                            	if(!str.contains(".css") && !str.endsWith(".js")) {
+                            		urlTemp = adicionaLink(str, base);
+                            	}
+                            	if(urlTemp!= null && urlTemp.startsWith("http")){
                                     try {
                                         ln = new LinkNeighborhood(new URL(urlTemp));
                                     } catch (Exception e) {
@@ -957,7 +960,6 @@ public class PaginaURL {
 //                                System.out.println("CREATE LINK:"  + urlTemp);
                             } else if (tagName.equals("area")
                                        && atributo.equals("href")) {
-                                adicionaLink(str, base);
                                 String urlTemp = adicionaLink(str, base);
                                 if(urlTemp!= null && urlTemp.startsWith("http")){
                                   ln = new LinkNeighborhood(new URL(urlTemp));


### PR DESCRIPTION
Currently it is ignoring all links in the link tag ending with .css and .js. 
I noticed that the script tag links were not getting added to the array list in the PaginaUrl class but links were getting added via link tag so made a check there.
Currently the code checks for ".css" rather than just "css". Hence, we have definitely reduced a lot of links which end with .css but we will still get links like "http://fonts.googleapis.com/css?family=Oswald%3A400%2C700%2C300" in the frontier. Should I block such links too?